### PR TITLE
Add SwiftUI POI app

### DIFF
--- a/POIApp/ContentView.swift
+++ b/POIApp/ContentView.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import MapKit
+
+struct ContentView: View {
+    @State private var region = MKCoordinateRegion(
+        center: CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780),
+        span: MKCoordinateSpan(latitudeDelta: 0.05, longitudeDelta: 0.05)
+    )
+
+    var body: some View {
+        TabView {
+            NavigationView {
+                Map(coordinateRegion: $region, annotationItems: samplePOIs) { poi in
+                    MapMarker(coordinate: poi.coordinate)
+                }
+                .navigationTitle("POI Map")
+            }
+            .tabItem {
+                Label("Map", systemImage: "map")
+            }
+
+            NavigationView {
+                POIListView(pois: samplePOIs)
+                    .navigationTitle("POI List")
+            }
+            .tabItem {
+                Label("List", systemImage: "list.bullet")
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}
+#endif

--- a/POIApp/Models/POI.swift
+++ b/POIApp/Models/POI.swift
@@ -1,0 +1,13 @@
+import Foundation
+import CoreLocation
+
+struct POI: Identifiable {
+    let id = UUID()
+    let name: String
+    let coordinate: CLLocationCoordinate2D
+}
+
+let samplePOIs: [POI] = [
+    POI(name: "Seoul City Hall", coordinate: CLLocationCoordinate2D(latitude: 37.5665, longitude: 126.9780)),
+    POI(name: "Namsan Tower", coordinate: CLLocationCoordinate2D(latitude: 37.5512, longitude: 126.9882))
+]

--- a/POIApp/POIAppApp.swift
+++ b/POIApp/POIAppApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct POIAppApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/POIApp/README.md
+++ b/POIApp/README.md
@@ -1,0 +1,14 @@
+# POIApp
+
+A simple SwiftUI application that displays a map with points of interest (POI) and a list view.
+
+## Requirements
+- Xcode 14 or later
+- iOS 16 SDK
+
+## Building
+1. Open the `POIApp` folder in Xcode as a new project.
+2. Select an iOS simulator or a connected device.
+3. Build and run the app.
+
+This project uses `MapKit` and `SwiftUI` to render POIs on the map. The sample data is in `Models/POI.swift`.

--- a/POIApp/Views/POIListView.swift
+++ b/POIApp/Views/POIListView.swift
@@ -1,0 +1,24 @@
+import SwiftUI
+
+struct POIListView: View {
+    var pois: [POI]
+
+    var body: some View {
+        List(pois) { poi in
+            VStack(alignment: .leading) {
+                Text(poi.name)
+                    .font(.headline)
+                Text("lat: \(poi.coordinate.latitude), lon: \(poi.coordinate.longitude)")
+                    .font(.subheadline)
+            }
+        }
+    }
+}
+
+#if DEBUG
+struct POIListView_Previews: PreviewProvider {
+    static var previews: some View {
+        POIListView(pois: samplePOIs)
+    }
+}
+#endif

--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # yjpark_app
+
+This repository contains a simple iOS application demonstrating Points of Interest (POI) using SwiftUI.
+
+See [POIApp](POIApp/README.md) for build instructions.


### PR DESCRIPTION
## Summary
- add a minimal SwiftUI POI app with map and list
- include a simple POI data model and sample POIs
- document build steps for the example app

## Testing
- `swift --version`
- `swiftc POIApp/POIAppApp.swift -o POIAppApp` *(fails: no such module 'SwiftUI')*